### PR TITLE
fix for ignoring submittet py venv

### DIFF
--- a/eprgrader.py
+++ b/eprgrader.py
@@ -156,7 +156,8 @@ def lint_files(folders, author_pairs, deduction: bool):
         count += 1
         print(f" ({str(count).rjust(len(str(total)))}/{total}) Checking {folder.name}")
         pythons = list(map(pathlib.Path.resolve,
-                           filter(lambda p: "__MACOSX" not in p.parts, folder.glob('**/*.py'))))
+                            filter(lambda p: "__MACOSX" not in p.parts and ".venv" not in p.parts,
+                                    folder.glob('**/*.py'))))
         if not pythons:
             continue
         pycount = 0


### PR DESCRIPTION
Hi,
bei mir hat bei Blatt 2 jemand seinen python `.venv` Ordner mit abgegeben und der epr_grader hat dann auf einmal angefangen über 1000 Dateien zu checken :joy: . Dieser fix ignoriert `.venv` Datei Pfade, ähnlich wie beim `__MACOSX` Ordner.